### PR TITLE
Potential fix for code scanning alert no. 9: Server-side request forgery

### DIFF
--- a/frontend/src/services/template-service/template-service.ts
+++ b/frontend/src/services/template-service/template-service.ts
@@ -47,11 +47,26 @@ export interface ChecklistWithOrgId extends Checklist {
   phases: PhaseWithOrgId[];
 }
 
+// Helper functions to validate orgId and templateId
+function isValidOrgId(orgId: string): boolean {
+  return /^\d+$/.test(orgId);
+}
+function isValidTemplateId(templateId: string): boolean {
+  // Accepts only digits; adjust regex if templateId can be UUID or other format
+  return /^\d+$/.test(templateId);
+}
+
 export const setSortorder: (
   orgId: string,
   templateId: string,
   sortOrderData: SortorderRequest
 ) => Promise<SortorderRequest> = async (orgId, templateId, sortOrderData) => {
+  if (!isValidOrgId(orgId)) {
+    throw new Error(`Invalid orgId: ${orgId}`);
+  }
+  if (!isValidTemplateId(templateId)) {
+    throw new Error(`Invalid templateId: ${templateId}`);
+  }
   return apiService
     .put<SortorderRequest>(`/org/${orgId}/templates/${templateId}/sortorder`, sortOrderData)
     .then((response) => {


### PR DESCRIPTION
Potential fix for [https://github.com/Sundsvallskommun/web-app-boarding/security/code-scanning/9](https://github.com/Sundsvallskommun/web-app-boarding/security/code-scanning/9)

To fix this issue, we need to ensure that user-controlled values (`orgid`, `templateid`) used in API endpoint paths are validated or sanitized before being used to construct URLs. The best approach is to validate that `orgid` is a numeric string (since it is parsed as an integer elsewhere) and that `templateid` matches the expected format (e.g., a UUID or a numeric string, depending on backend requirements). This validation should be performed as close as possible to where the values are first extracted from user input, ideally in the page/component where `router.query` is used, or in the service function before constructing the URL.

For this codebase, the most robust and non-intrusive fix is to add validation in the `setSortorder` function in `template-service.ts`, since this is where the tainted values are first used to construct the API path. We will:
- Add helper functions to validate `orgId` (must be a string of digits) and `templateId` (must be a string of digits or a UUID, depending on requirements; for now, we'll assume digits).
- Throw an error if validation fails, preventing the API call with a malformed URL.
- Optionally, we can also sanitize the values by stripping out any non-allowed characters.

No changes are needed in `api-service.ts` or `api-url.ts` since the fix is best applied at the service layer where the user input is first used.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
