### PR TITLE
Potential fix for code scanning alert no. 6: Server-side request forgery

### DIFF
--- a/frontend/src/services/checklist-service/checklist-service.ts
+++ b/frontend/src/services/checklist-service/checklist-service.ts
@@ -13,7 +13,13 @@ import {
   COngoingEmployeeChecklists,
 } from '@data-contracts/backend/data-contracts';
 
+// Allow only alphanumeric, underscore, hyphen, and dot in usernames
+const isValidUsername = (username: string): boolean => /^[a-zA-Z0-9_.-]+$/.test(username);
+
 export const getChecklistAsEmployee: (username: string) => Promise<EmployeeChecklist> = async (username: string) => {
+  if (!isValidUsername(username)) {
+    return Promise.reject(new Error('Invalid username'));
+  }
   return await apiService
     .get<ApiResponse<EmployeeChecklist>>(`/employee-checklists/employee/${username}`)
     .then((res) => {
@@ -24,6 +30,9 @@ export const getChecklistAsEmployee: (username: string) => Promise<EmployeeCheck
     });
 };
 
+  if (!isValidUsername(username)) {
+    return Promise.reject(new Error('Invalid username'));
+  }
 export const getChecklistsAsManager: (username: string) => Promise<EmployeeChecklist[]> = async (username: string) => {
   return apiService
     .get<ApiResponse<EmployeeChecklist[]>>(`/employee-checklists/manager/${username}`)
@@ -41,6 +50,9 @@ export const getChecklistsAsManager: (username: string) => Promise<EmployeeCheck
 
 export const getDelegatedChecklists: (username: string) => Promise<DelegatedEmployeeChecklistResponse> = async (
   username: string
+  if (!isValidUsername(username)) {
+    return Promise.reject(new Error('Invalid username'));
+  }
 ) => {
   return apiService
     .get<ApiResponse<DelegatedEmployeeChecklistResponse>>(`/employee-checklists/delegated-to/${username}`)


### PR DESCRIPTION
Potential fix for [https://github.com/Sundsvallskommun/web-app-boarding/security/code-scanning/6](https://github.com/Sundsvallskommun/web-app-boarding/security/code-scanning/6)

To fix this SSRF vulnerability, we need to ensure that the `username` (derived from `query.userId`) is validated before it is used to construct the API request path. The best approach is to restrict the allowed characters in the username to a safe subset (e.g., alphanumeric, underscores, hyphens), and reject or sanitize any input that does not conform. This validation should be performed as close as possible to the point where the user input is first received or before it is used in constructing the API URL.

The most appropriate place to add this validation is in the `getChecklistAsEmployee` function in `frontend/src/services/checklist-service/checklist-service.ts`, since this is where the username is interpolated into the API path. We can define a helper function (e.g., `isValidUsername`) that uses a regular expression to check that the username only contains allowed characters. If the username is invalid, we should throw an error or return a rejected promise.

**Required changes:**
- In `frontend/src/services/checklist-service/checklist-service.ts`, add a helper function `isValidUsername`.
- Before making the API call in `getChecklistAsEmployee`, check if the username is valid.
- If not valid, throw an error or return a rejected promise.
- Optionally, apply the same validation in other functions that use username in API paths (e.g., `getChecklistsAsManager`, `getDelegatedChecklists`).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
